### PR TITLE
Remove setuptools as runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,135 @@ test:
     - pip
   commands:
     - pip check
+    - conda install -y numpy
+    - python test-imports-requiring-numpy.py
+    - conda install -y matplotlib-base
+    - python test-imports-requiring-matplotlib.py
+    - conda install -y pandas
+    - python test-imports-requiring-pandas.py
+  files:
+    - test-imports-requiring-numpy.py
+    - test-imports-requiring-matplotlib.py
+    - test-imports-requiring-pandas.py
   imports:
+    # From setup.py
+    - jupyterlab_plotly
     - plotly
+    # - plotly.plotly (deprecated)
+    - plotly.offline
+    - plotly.io
+    # - plotly.matplotlylib (requires matplotlib)
+    # - plotly.matplotlylib.mplexporter (requires matplotlib)
+    # - plotly.matplotlylib.mplexporter.renderers (requires matplotlib)
+    # - plotly.figure_factory (requires numpy)
+    - plotly.data
+    - plotly.colors
+    # - plotly.express (requires pandas)
+    # - plotly.express.data (requires pandas)
+    # - plotly.express.colors (requires pandas)
+    # - plotly.express.trendline_functions (requires pandas)
+    - plotly.graph_objects
+    - _plotly_utils
+    - _plotly_utils.colors
+    - _plotly_future_
+    - plotly.graph_objs.bar
+    - plotly.graph_objs.barpolar
+    - plotly.graph_objs.box
+    - plotly.graph_objs.candlestick
+    - plotly.graph_objs.carpet
+    - plotly.graph_objs.choropleth
+    - plotly.graph_objs.choroplethmapbox
+    - plotly.graph_objs.cone
+    - plotly.graph_objs.contour
+    - plotly.graph_objs.contourcarpet
+    - plotly.graph_objs.densitymapbox
+    - plotly.graph_objs.funnel
+    - plotly.graph_objs.funnelarea
+    - plotly.graph_objs.heatmap
+    - plotly.graph_objs.heatmapgl
+    - plotly.graph_objs.histogram
+    - plotly.graph_objs.histogram2d
+    - plotly.graph_objs.histogram2dcontour
+    - plotly.graph_objs.icicle
+    - plotly.graph_objs.image
+    - plotly.graph_objs.indicator
+    - plotly.graph_objs.isosurface
+    - plotly.graph_objs.layout
+    - plotly.graph_objs.mesh3d
+    - plotly.graph_objs.ohlc
+    - plotly.graph_objs.parcats
+    - plotly.graph_objs.parcoords
+    - plotly.graph_objs.pie
+    - plotly.graph_objs.pointcloud
+    - plotly.graph_objs.sankey
+    - plotly.graph_objs.scatter
+    - plotly.graph_objs.scatter3d
+    - plotly.graph_objs.scattercarpet
+    - plotly.graph_objs.scattergeo
+    - plotly.graph_objs.scattergl
+    - plotly.graph_objs.scattermapbox
+    - plotly.graph_objs.scatterpolar
+    - plotly.graph_objs.scatterpolargl
+    - plotly.graph_objs.scatterternary
+    - plotly.graph_objs.splom
+    - plotly.graph_objs.streamtube
+    - plotly.graph_objs.sunburst
+    - plotly.graph_objs.surface
+    - plotly.graph_objs.table
+    - plotly.graph_objs.treemap
+    - plotly.graph_objs.violin
+    - plotly.graph_objs.volume
+    - plotly.graph_objs.waterfall
+    - plotly.validators
+    - plotly.validators.bar
+    - plotly.validators.barpolar
+    - plotly.validators.box
+    - plotly.validators.candlestick
+    - plotly.validators.carpet
+    - plotly.validators.choropleth
+    - plotly.validators.choroplethmapbox
+    - plotly.validators.cone
+    - plotly.validators.contour
+    - plotly.validators.contourcarpet
+    - plotly.validators.densitymapbox
+    - plotly.validators.frame
+    - plotly.validators.funnel
+    - plotly.validators.funnelarea
+    - plotly.validators.heatmap
+    - plotly.validators.heatmapgl
+    - plotly.validators.histogram
+    - plotly.validators.histogram2d
+    - plotly.validators.histogram2dcontour
+    - plotly.validators.icicle
+    - plotly.validators.image
+    - plotly.validators.indicator
+    - plotly.validators.isosurface
+    - plotly.validators.layout
+    - plotly.validators.mesh3d
+    - plotly.validators.ohlc
+    - plotly.validators.parcats
+    - plotly.validators.parcoords
+    - plotly.validators.pie
+    - plotly.validators.pointcloud
+    - plotly.validators.sankey
+    - plotly.validators.scatter
+    - plotly.validators.scatter3d
+    - plotly.validators.scattercarpet
+    - plotly.validators.scattergeo
+    - plotly.validators.scattergl
+    - plotly.validators.scattermapbox
+    - plotly.validators.scatterpolar
+    - plotly.validators.scatterpolargl
+    - plotly.validators.scatterternary
+    - plotly.validators.splom
+    - plotly.validators.streamtube
+    - plotly.validators.sunburst
+    - plotly.validators.surface
+    - plotly.validators.table
+    - plotly.validators.treemap
+    - plotly.validators.violin
+    - plotly.validators.volume
+    - plotly.validators.waterfall
 
 about:
   home: https://plot.ly/python/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1575c34f87313818fc109a3d3326f2b91363d049c1e80cbf68561c8df24fb47c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -17,9 +17,9 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools >=40.8.0  # min version from pyproject.toml
   run:
     - python >=3.6
-    - setuptools
     - tenacity >=6.2.0
     - six
 

--- a/recipe/test-imports-requiring-matplotlib.py
+++ b/recipe/test-imports-requiring-matplotlib.py
@@ -1,0 +1,3 @@
+import plotly.matplotlylib
+import plotly.matplotlylib.mplexporter
+import plotly.matplotlylib.mplexporter.renderers

--- a/recipe/test-imports-requiring-numpy.py
+++ b/recipe/test-imports-requiring-numpy.py
@@ -1,0 +1,1 @@
+import plotly.figure_factory

--- a/recipe/test-imports-requiring-pandas.py
+++ b/recipe/test-imports-requiring-pandas.py
@@ -1,0 +1,4 @@
+import plotly.express
+import plotly.express.data
+import plotly.express.colors
+import plotly.express.trendline_functions


### PR DESCRIPTION
Setuptools was added in https://github.com/conda-forge/plotly-feedstock/commit/9aeba4987669db29659e4db2e2ad0e0ad1c59c11 to fix missing pkg_resources. But pkg_resources was [removed in v3.3.0](https://github.com/plotly/plotly.py/blob/c1166729192e5278fb18c5165cd1b88d9dd5c07c/CHANGELOG.md#fixed-36).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
