### PR TITLE
Add a run_constrained for ipywidgets

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4efef479c2ec1d86dcdac8405b6ca70ca65649a77408e39a7e84a1ea2db6c787
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -23,6 +23,11 @@ requirements:
     # Check install_requires=[...] in
     # <https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/setup.py>
     - tenacity >=6.2.0
+  run_constrained:
+    # This ensures that if ipywidgets is installed, then the version is compatible with Plotly.
+    # The lower bound of 7.6 comes from README.md.
+    # The upper bound <8 is due to <https://github.com/plotly/plotly.py/issues/3686>.
+    - ipywidgets >=7.6,<8
 
 test:
   requires:


### PR DESCRIPTION
This won't do much until we get a repodata patch in place as per https://github.com/conda-forge/plotly-feedstock/issues/115, but I think it's the correct first step.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
